### PR TITLE
Add Start screen component

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,3 +1,5 @@
 {
-  "welcome": "Welcome"
+  "welcome": "Welcome",
+  "game_title": "The Advisor",
+  "start_game": "Start Game"
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1,3 +1,5 @@
 {
-  "welcome": "Bienvenido"
+  "welcome": "Bienvenido",
+  "game_title": "El Consejero",
+  "start_game": "Comenzar juego"
 }

--- a/src/lib/startLogic.ts
+++ b/src/lib/startLogic.ts
@@ -1,0 +1,5 @@
+import { useGameState } from '../state/gameState'
+
+export function goToLevelSelect() {
+  useGameState.getState().updateVariable('currentScreen', 'levelSelect')
+}

--- a/src/screens/StartScreen.tsx
+++ b/src/screens/StartScreen.tsx
@@ -1,0 +1,13 @@
+import { useTranslation } from 'react-i18next'
+import { goToLevelSelect } from '../lib/startLogic'
+
+export default function StartScreen() {
+  const { t } = useTranslation()
+
+  return (
+    <div className="start-screen">
+      <h1>{t('game_title')}</h1>
+      <button onClick={goToLevelSelect}>{t('start_game')}</button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create StartScreen component
- add startLogic helper for navigation to level select
- add translation keys for game title and start button

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6852a9724e2c8328b3183a44389692f4