### PR TITLE
Render StartScreen via Zustand

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,35 +1,14 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import StartScreen from './screens/StartScreen'
+import { useGameState } from './state/gameState'
 
 function App() {
-  const [count, setCount] = useState(0)
+  const currentScreen = useGameState((state) => state.currentScreen)
 
-  return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+  if (currentScreen === 'start') {
+    return <StartScreen />
+  }
+
+  return null
 }
 
 export default App


### PR DESCRIPTION
## Summary
- show `StartScreen` based on Zustand game state
- drop the unused Vite template code in `App.tsx`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6852ab04cf348328aee3332fec8e6f82