### PR TITLE
Improve start screen styling and i18n setup

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -40,3 +40,29 @@
 .read-the-docs {
   color: #888;
 }
+
+.start-screen {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.start-screen h1 {
+  font-size: 3rem;
+  margin-bottom: 2rem;
+}
+
+.start-screen button {
+  padding: 1rem 2rem;
+  font-size: 1.25rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  transition: background-color 0.3s, box-shadow 0.3s;
+}
+
+.start-screen button:hover {
+  background-color: #2a2a2a;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
+import './i18n'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(


### PR DESCRIPTION
## Summary
- load translations during app startup
- style the start screen with flex layout and modern button styles

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6852adc9ac708328a8ecdaffd63282b7