### PR TITLE
Improve start screen layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -43,15 +43,25 @@
 
 .start-screen {
   display: flex;
-  flex-direction: column;
   justify-content: center;
   align-items: center;
   min-height: 100vh;
+  width: 100vw;
+  text-align: center;
+  padding: 2rem;
+  background: linear-gradient(135deg, #f5f7fa, #c3cfe2);
+}
+
+.start-screen .content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: 600px;
 }
 
 .start-screen h1 {
   font-size: 3rem;
-  margin-bottom: 2rem;
+  margin-bottom: 1.5rem;
 }
 
 .start-screen button {

--- a/src/screens/StartScreen.tsx
+++ b/src/screens/StartScreen.tsx
@@ -6,8 +6,10 @@ export default function StartScreen() {
 
   return (
     <div className="start-screen">
-      <h1>{t('game_title')}</h1>
-      <button onClick={goToLevelSelect}>{t('start_game')}</button>
+      <div className="content">
+        <h1>{t('game_title')}</h1>
+        <button onClick={goToLevelSelect}>{t('start_game')}</button>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- center the start screen with new flex layout
- wrap start screen contents in a `.content` container
- apply subtle gradient background and adjust spacing

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6852af94ec608328a60d24b4a1bfe654