### PR TITLE
Fix root layout centering

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,8 +1,13 @@
 #root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
+  /* max-width: 1280px; */
+  /* margin: 0 auto; */
+  /* padding: 2rem; */
   text-align: center;
+  height: 100vh;
+  width: 100vw;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .logo {
@@ -45,8 +50,8 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  min-height: 100vh;
-  width: 100vw;
+  width: 100%;
+  height: 100%;
   text-align: center;
   padding: 2rem;
   background: linear-gradient(135deg, #f5f7fa, #c3cfe2);


### PR DESCRIPTION
## Summary
- center root container flexibly to keep start screen centered
- ensure start screen fills the root container

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6852b0f398788328acbfad9727f92e9a