### PR TITLE
Enhance StartScreen title

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -64,9 +64,14 @@
   max-width: 600px;
 }
 
-.start-screen h1 {
-  font-size: 3rem;
+.start-screen .title {
+  font-size: 4rem;
   margin-bottom: 1.5rem;
+  text-align: center;
+  background: linear-gradient(90deg, #ff7e5f, #feb47b);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
 }
 
 .start-screen button {

--- a/src/screens/StartScreen.tsx
+++ b/src/screens/StartScreen.tsx
@@ -7,7 +7,7 @@ export default function StartScreen() {
   return (
     <div className="start-screen">
       <div className="content">
-        <h1>{t('game_title')}</h1>
+        <h1 className="title">{t('game_title')}</h1>
         <button onClick={goToLevelSelect}>{t('start_game')}</button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- give the StartScreen title its own class
- add gradient text style so the title is centered and more appealing

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6852b22e13488328aac54648de585fa2