### PR TITLE
Implement level select screen

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -87,3 +87,60 @@
   transform: translateY(-2px);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
 }
+
+.level-select-screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  min-height: 100vh;
+  text-align: center;
+  background: linear-gradient(135deg, #f5f7fa, #c3cfe2);
+}
+
+.level-select-screen .title {
+  font-size: clamp(2rem, 5vw, 3rem);
+  margin-bottom: 2rem;
+}
+
+.level-select-screen .levels {
+  display: grid;
+  gap: 1rem;
+  width: 100%;
+  max-width: 800px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.level-card {
+  background: #ffffff;
+  color: #333;
+  border: none;
+  border-radius: 0.5rem;
+  padding: 1.25rem;
+  text-align: left;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.level-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
+}
+
+.level-card h3 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
+
+.level-card p {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .level-card {
+    background: #1a1a1a;
+    color: #fff;
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import StartScreen from './screens/StartScreen'
+import LevelSelectScreen from './screens/LevelSelectScreen'
 import { useGameState } from './state/gameState'
 
 function App() {
@@ -6,6 +7,10 @@ function App() {
 
   if (currentScreen === 'start') {
     return <StartScreen />
+  }
+
+  if (currentScreen === 'levelSelect') {
+    return <LevelSelectScreen />
   }
 
   return null

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,5 +1,16 @@
 {
   "welcome": "Welcome",
   "game_title": "The Advisor",
-  "start_game": "Start Game"
+  "start_game": "Start Game",
+  "select_level": "Select Your Starting Level",
+  "level_village": "Village",
+  "level_village_description": "Start your adventure in a small village.",
+  "level_governor": "Governor",
+  "level_governor_description": "Begin as a local governor in charge of a province.",
+  "level_royal": "Royal Court",
+  "level_royal_description": "Serve at the royal court from the start.",
+  "level_mythical": "Mythical Realm",
+  "level_mythical_description": "Enter the realm of myths and legends.",
+  "level_oracle": "Legendary Oracle",
+  "level_oracle_description": "Seek wisdom from the legendary oracle."
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1,5 +1,16 @@
 {
   "welcome": "Bienvenido",
   "game_title": "El Consejero",
-  "start_game": "Comenzar juego"
+  "start_game": "Comenzar juego",
+  "select_level": "Selecciona tu nivel inicial",
+  "level_village": "Aldea",
+  "level_village_description": "Comienza tu aventura en una pequeña aldea.",
+  "level_governor": "Gobernador",
+  "level_governor_description": "Empieza como un gobernador local a cargo de una provincia.",
+  "level_royal": "Corte Real",
+  "level_royal_description": "Sirve en la corte real desde el principio.",
+  "level_mythical": "Reino Mitológico",
+  "level_mythical_description": "Entra en el reino de los mitos y las leyendas.",
+  "level_oracle": "Oráculo Legendario",
+  "level_oracle_description": "Busca sabiduría en el oráculo legendario."
 }

--- a/src/lib/levelSelectLogic.ts
+++ b/src/lib/levelSelectLogic.ts
@@ -1,0 +1,21 @@
+import { useGameState } from '../state/gameState'
+
+export interface LevelOption {
+  key: string
+  nameKey: string
+  descriptionKey: string
+}
+
+export const levelOptions: LevelOption[] = [
+  { key: 'village', nameKey: 'level_village', descriptionKey: 'level_village_description' },
+  { key: 'governor', nameKey: 'level_governor', descriptionKey: 'level_governor_description' },
+  { key: 'royal', nameKey: 'level_royal', descriptionKey: 'level_royal_description' },
+  { key: 'mythical', nameKey: 'level_mythical', descriptionKey: 'level_mythical_description' },
+  { key: 'oracle', nameKey: 'level_oracle', descriptionKey: 'level_oracle_description' },
+]
+
+export function selectLevel(level: string) {
+  const state = useGameState.getState()
+  state.updateVariable('selectedLevel', level)
+  state.updateVariable('currentScreen', 'presentacionRey')
+}

--- a/src/screens/LevelSelectScreen.tsx
+++ b/src/screens/LevelSelectScreen.tsx
@@ -1,0 +1,24 @@
+import { useTranslation } from 'react-i18next'
+import { levelOptions, selectLevel } from '../lib/levelSelectLogic'
+
+export default function LevelSelectScreen() {
+  const { t } = useTranslation()
+
+  return (
+    <main className="level-select-screen">
+      <h2 className="title">{t('select_level')}</h2>
+      <div className="levels">
+        {levelOptions.map((level) => (
+          <button
+            key={level.key}
+            className="level-card"
+            onClick={() => selectLevel(level.key)}
+          >
+            <h3>{t(level.nameKey)}</h3>
+            <p>{t(level.descriptionKey)}</p>
+          </button>
+        ))}
+      </div>
+    </main>
+  )
+}

--- a/src/state/gameState.ts
+++ b/src/state/gameState.ts
@@ -14,6 +14,7 @@ export interface GameState {
     reputation: number
   }
   currentScreen: string
+  selectedLevel: string
   narrativeMemory: string[]
   updateVariable: (path: string, value: unknown) => void
   resetGame: () => void
@@ -33,6 +34,7 @@ const initialState = {
     reputation: 50,
   },
   currentScreen: 'start',
+  selectedLevel: '',
   narrativeMemory: [] as string[],
 }
 


### PR DESCRIPTION
## Summary
- add new level select screen and logic
- track selected level in game state
- support localization for level selection
- style the level select screen

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6852b7db71908328b6f7d4b35e99d485