### PR TITLE
Add presentation screen with placeholder king info

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -144,3 +144,56 @@
     color: #fff;
   }
 }
+.presentation-screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 2rem;
+  gap: 1.5rem;
+  text-align: center;
+  background: linear-gradient(135deg, #f5f7fa, #c3cfe2);
+}
+
+.presentation-screen .title {
+  font-size: clamp(2rem, 6vw, 3rem);
+  margin: 0 0 1rem;
+  background: linear-gradient(90deg, #ff7e5f, #feb47b);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+.king-info,
+.kingdom-info {
+  background: #ffffff;
+  color: #333;
+  padding: 1rem 1.5rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  max-width: 600px;
+}
+
+.king-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.presentation-screen button {
+  padding: 0.75rem 2rem;
+  font-size: 1.1rem;
+  border: none;
+  border-radius: 0.5rem;
+  color: #fff;
+  background: linear-gradient(90deg, #667eea, #764ba2);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.presentation-screen button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+}
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import StartScreen from './screens/StartScreen'
 import LevelSelectScreen from './screens/LevelSelectScreen'
+import PresentationScreen from './screens/PresentationScreen'
 import { useGameState } from './state/gameState'
 
 function App() {
@@ -11,6 +12,10 @@ function App() {
 
   if (currentScreen === 'levelSelect') {
     return <LevelSelectScreen />
+  }
+
+  if (currentScreen === 'presentation') {
+    return <PresentationScreen />
   }
 
   return null

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -12,5 +12,7 @@
   "level_mythical": "Mythical Realm",
   "level_mythical_description": "Enter the realm of myths and legends.",
   "level_oracle": "Legendary Oracle",
-  "level_oracle_description": "Seek wisdom from the legendary oracle."
+  "level_oracle_description": "Seek wisdom from the legendary oracle.",
+  "presentation_title": "Your role begins now...",
+  "continue": "Continue"
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -12,5 +12,7 @@
   "level_mythical": "Reino Mitológico",
   "level_mythical_description": "Entra en el reino de los mitos y las leyendas.",
   "level_oracle": "Oráculo Legendario",
-  "level_oracle_description": "Busca sabiduría en el oráculo legendario."
+  "level_oracle_description": "Busca sabiduría en el oráculo legendario.",
+  "presentation_title": "Tu papel comienza ahora...",
+  "continue": "Continuar"
 }

--- a/src/lib/levelSelectLogic.ts
+++ b/src/lib/levelSelectLogic.ts
@@ -17,5 +17,5 @@ export const levelOptions: LevelOption[] = [
 export function selectLevel(level: string) {
   const state = useGameState.getState()
   state.updateVariable('selectedLevel', level)
-  state.updateVariable('currentScreen', 'presentacionRey')
+  state.updateVariable('currentScreen', 'presentation')
 }

--- a/src/screens/PresentationScreen.tsx
+++ b/src/screens/PresentationScreen.tsx
@@ -1,0 +1,26 @@
+import { useTranslation } from 'react-i18next'
+import { useGameState } from '../state/gameState'
+
+export default function PresentationScreen() {
+  const { t } = useTranslation()
+
+  const continueToGame = () => {
+    useGameState.getState().updateVariable('currentScreen', 'firstTurn')
+  }
+
+  return (
+    <main className="presentation-screen">
+      <h2 className="title">{t('presentation_title')}</h2>
+      <div className="king-info">
+        <p><strong>Ulric</strong>, the Raven</p>
+        <p>Personality: paranoid and meticulous</p>
+        <p>Throne: A dark hall lit by torches, tapestries worn by time.</p>
+        <p>Quote: "I warn you: I do not tolerate failure."</p>
+      </div>
+      <div className="kingdom-info">
+        <p>Context: A realm marked by betrayal and plague.</p>
+      </div>
+      <button onClick={continueToGame}>{t('continue')}</button>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- introduce `PresentationScreen` component and styling
- add i18n keys for presentation screen
- update level selection logic and App to navigate to presentation screen

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6852ba07515083288caf97174023d9fe