### PR TITLE
Add Turn screen component

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -197,3 +197,58 @@
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
 }
 
+.turn-screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2rem 1rem;
+  min-height: 100vh;
+  background: linear-gradient(135deg, #f5f7fa, #c3cfe2);
+}
+
+.turn-screen .title {
+  font-size: clamp(1.75rem, 5vw, 2.5rem);
+  margin-bottom: 1rem;
+  text-align: center;
+}
+
+.turn-screen .dilemma-block,
+.turn-screen .advice-block,
+.turn-screen .submit-block {
+  background: #ffffff;
+  color: #333;
+  width: 100%;
+  max-width: 800px;
+  padding: 1rem 1.5rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  margin-bottom: 1rem;
+}
+
+.turn-screen textarea {
+  width: 100%;
+  resize: none;
+  border: 1px solid #ccc;
+  border-radius: 0.5rem;
+  padding: 0.75rem;
+  font-size: 1rem;
+  box-sizing: border-box;
+  min-height: 100px;
+}
+
+.turn-screen button {
+  padding: 0.75rem 2rem;
+  font-size: 1.1rem;
+  border: none;
+  border-radius: 0.5rem;
+  color: #fff;
+  background: linear-gradient(90deg, #667eea, #764ba2);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.turn-screen button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+}
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import StartScreen from './screens/StartScreen'
 import LevelSelectScreen from './screens/LevelSelectScreen'
 import PresentationScreen from './screens/PresentationScreen'
+import TurnScreen from './screens/TurnScreen'
 import { useGameState } from './state/gameState'
 
 function App() {
@@ -16,6 +17,10 @@ function App() {
 
   if (currentScreen === 'presentation') {
     return <PresentationScreen />
+  }
+
+  if (currentScreen === 'turn') {
+    return <TurnScreen />
   }
 
   return null

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -14,5 +14,8 @@
   "level_oracle": "Legendary Oracle",
   "level_oracle_description": "Seek wisdom from the legendary oracle.",
   "presentation_title": "Your role begins now...",
-  "continue": "Continue"
+  "continue": "Continue",
+  "your_advice_title": "What do you advise the King?",
+  "your_advice_label": "Your advice",
+  "send_advice": "Send Advice"
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -14,5 +14,8 @@
   "level_oracle": "Oráculo Legendario",
   "level_oracle_description": "Busca sabiduría en el oráculo legendario.",
   "presentation_title": "Tu papel comienza ahora...",
-  "continue": "Continuar"
+  "continue": "Continuar",
+  "your_advice_title": "¿Qué aconsejas al Rey?",
+  "your_advice_label": "Tu consejo",
+  "send_advice": "Enviar consejo"
 }

--- a/src/screens/PresentationScreen.tsx
+++ b/src/screens/PresentationScreen.tsx
@@ -5,7 +5,7 @@ export default function PresentationScreen() {
   const { t } = useTranslation()
 
   const continueToGame = () => {
-    useGameState.getState().updateVariable('currentScreen', 'firstTurn')
+    useGameState.getState().updateVariable('currentScreen', 'turn')
   }
 
   return (

--- a/src/screens/TurnScreen.tsx
+++ b/src/screens/TurnScreen.tsx
@@ -1,0 +1,40 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useGameState } from '../state/gameState'
+
+export default function TurnScreen() {
+  const { t } = useTranslation()
+  const [advice, setAdvice] = useState('')
+
+  const handleSubmit = () => {
+    if (!advice.trim()) return
+    const state = useGameState.getState()
+    state.setCurrentAdvice(advice.trim())
+    state.updateVariable('currentScreen', 'reaction')
+  }
+
+  return (
+    <main className="turn-screen">
+      <h2 className="title">{t('your_advice_title')}</h2>
+      <section className="dilemma-block">
+        <h3 className="dilemma-title">A nobleman accuses the tax collector of corruption</h3>
+        <p className="dilemma-text">The nobleman has presented evidence. The tax collector denies all.</p>
+      </section>
+      <section className="advice-block">
+        <h4>{t('your_advice_label')}</h4>
+        <textarea
+          value={advice}
+          onChange={(e) => setAdvice(e.target.value)}
+          onInput={(e) => {
+            e.currentTarget.style.height = 'auto'
+            e.currentTarget.style.height = `${e.currentTarget.scrollHeight}px`
+          }}
+          placeholder="Write your advice to the King here..."
+        />
+      </section>
+      <section className="submit-block">
+        <button onClick={handleSubmit}>{t('send_advice')}</button>
+      </section>
+    </main>
+  )
+}

--- a/src/state/gameState.ts
+++ b/src/state/gameState.ts
@@ -16,6 +16,8 @@ export interface GameState {
   currentScreen: string
   selectedLevel: string
   narrativeMemory: string[]
+  currentAdvice: string
+  setCurrentAdvice: (advice: string) => void
   updateVariable: (path: string, value: unknown) => void
   resetGame: () => void
 }
@@ -36,6 +38,7 @@ const initialState = {
   currentScreen: 'start',
   selectedLevel: '',
   narrativeMemory: [] as string[],
+  currentAdvice: '',
 }
 
 export const useGameState = create<GameState>((set) => ({
@@ -51,4 +54,5 @@ export const useGameState = create<GameState>((set) => ({
       return { ...state }
     }),
   resetGame: () => set(initialState),
+  setCurrentAdvice: (advice) => set({ currentAdvice: advice }),
 }))


### PR DESCRIPTION
## Summary
- implement new `TurnScreen` with dilemma and advice textarea
- wire up `TurnScreen` in `App`
- add `currentAdvice` field to Zustand store
- update `PresentationScreen` to proceed to `turn`
- add translations for advice screen text
- style new screen in CSS

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6852bf33a30c8328b601b75443e55e0b