### PR TITLE
Add ReactionScreen with styling and translations

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -252,3 +252,39 @@
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
 }
 
+.reaction-screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2rem 1rem;
+  min-height: 100vh;
+  background: linear-gradient(135deg, #f5f7fa, #c3cfe2);
+}
+
+.reaction-screen .card {
+  background: #ffffff;
+  color: #333;
+  width: 100%;
+  max-width: 800px;
+  padding: 1rem 1.5rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  margin-bottom: 1rem;
+}
+
+.reaction-screen button {
+  padding: 0.75rem 2rem;
+  font-size: 1.1rem;
+  border: none;
+  border-radius: 0.5rem;
+  color: #fff;
+  background: linear-gradient(90deg, #667eea, #764ba2);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.reaction-screen button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+}
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import StartScreen from './screens/StartScreen'
 import LevelSelectScreen from './screens/LevelSelectScreen'
 import PresentationScreen from './screens/PresentationScreen'
 import TurnScreen from './screens/TurnScreen'
+import ReactionScreen from './screens/ReactionScreen'
 import { useGameState } from './state/gameState'
 
 function App() {
@@ -21,6 +22,10 @@ function App() {
 
   if (currentScreen === 'turn') {
     return <TurnScreen />
+  }
+
+  if (currentScreen === 'reaction') {
+    return <ReactionScreen />
   }
 
   return null

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -17,5 +17,8 @@
   "continue": "Continue",
   "your_advice_title": "What do you advise the King?",
   "your_advice_label": "Your advice",
-  "send_advice": "Send Advice"
+  "send_advice": "Send Advice",
+  "king_reaction_title": "The King's Response",
+  "king_emotion_placeholder": "The King looks at you with suspicion.",
+  "king_reaction_paragraph": "He listens carefully but seems unconvinced. He decides to delay his verdict."
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -17,5 +17,8 @@
   "continue": "Continuar",
   "your_advice_title": "¿Qué aconsejas al Rey?",
   "your_advice_label": "Tu consejo",
-  "send_advice": "Enviar consejo"
+  "send_advice": "Enviar consejo",
+  "king_reaction_title": "La reacción del Rey",
+  "king_emotion_placeholder": "El Rey te mira con desconfianza.",
+  "king_reaction_paragraph": "Te escucha con atención pero parece poco convencido. Decide aplazar su decisión."
 }

--- a/src/screens/ReactionScreen.tsx
+++ b/src/screens/ReactionScreen.tsx
@@ -1,0 +1,24 @@
+import { useTranslation } from 'react-i18next'
+import { useGameState } from '../state/gameState'
+
+export default function ReactionScreen() {
+  const { t } = useTranslation()
+  const update = useGameState((state) => state.updateVariable)
+
+  const handleContinue = () => {
+    update('currentScreen', 'turn')
+  }
+
+  return (
+    <main className="reaction-screen">
+      <h2 className="title">{t('king_reaction_title')}</h2>
+
+      <div className="card">
+        <p className="emotion-text">😐 {t('king_emotion_placeholder')}</p>
+        <p className="reaction-text">{t('king_reaction_paragraph')}</p>
+      </div>
+
+      <button onClick={handleContinue}>{t('continue')}</button>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- create `ReactionScreen` component for the king's narrative response
- integrate `ReactionScreen` into app routing
- style reaction screen to match turn screen layout
- add English and Spanish translations for new text

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6852edc06f848328819bc9ab0e17422d