### PR TITLE
Add FinalScreen for endgame narrative

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -288,3 +288,41 @@
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
 }
 
+.final-screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 2rem 1rem;
+  min-height: 100vh;
+  gap: 1rem;
+  background: linear-gradient(135deg, #f5f7fa, #c3cfe2);
+}
+
+.final-screen .reward-box {
+  background: #ffffff;
+  color: #333;
+  width: 100%;
+  max-width: 800px;
+  padding: 1rem 1.5rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.final-screen button {
+  padding: 0.75rem 2rem;
+  font-size: 1.1rem;
+  border: none;
+  border-radius: 0.5rem;
+  color: #fff;
+  background: linear-gradient(90deg, #667eea, #764ba2);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.final-screen button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+}
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import LevelSelectScreen from './screens/LevelSelectScreen'
 import PresentationScreen from './screens/PresentationScreen'
 import TurnScreen from './screens/TurnScreen'
 import ReactionScreen from './screens/ReactionScreen'
+import FinalScreen from './screens/FinalScreen'
 import { useGameState } from './state/gameState'
 
 function App() {
@@ -26,6 +27,10 @@ function App() {
 
   if (currentScreen === 'reaction') {
     return <ReactionScreen />
+  }
+
+  if (currentScreen === 'final') {
+    return <FinalScreen />
   }
 
   return null

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -20,5 +20,10 @@
   "send_advice": "Send Advice",
   "king_reaction_title": "The King's Response",
   "king_emotion_placeholder": "The King looks at you with suspicion.",
-  "king_reaction_paragraph": "He listens carefully but seems unconvinced. He decides to delay his verdict."
+  "king_reaction_paragraph": "He listens carefully but seems unconvinced. He decides to delay his verdict.",
+  "final_title": "Your Fate",
+  "final_description": "The end of your journey",
+  "card_unlocked": "New Card Unlocked",
+  "achievement_unlocked": "Achievement Unlocked",
+  "play_again": "Play Again"
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -20,5 +20,10 @@
   "send_advice": "Enviar consejo",
   "king_reaction_title": "La reacción del Rey",
   "king_emotion_placeholder": "El Rey te mira con desconfianza.",
-  "king_reaction_paragraph": "Te escucha con atención pero parece poco convencido. Decide aplazar su decisión."
+  "king_reaction_paragraph": "Te escucha con atención pero parece poco convencido. Decide aplazar su decisión.",
+  "final_title": "Tu destino",
+  "final_description": "El final de tu viaje",
+  "card_unlocked": "Carta desbloqueada",
+  "achievement_unlocked": "Logro obtenido",
+  "play_again": "Jugar otra vez"
 }

--- a/src/screens/FinalScreen.tsx
+++ b/src/screens/FinalScreen.tsx
@@ -1,0 +1,43 @@
+import { useTranslation } from 'react-i18next'
+import { useGameState } from '../state/gameState'
+
+export default function FinalScreen() {
+  const { t } = useTranslation()
+  const finalResult = useGameState((state) => state.finalResult)
+  const resetGame = useGameState((state) => state.resetGame)
+
+  if (!finalResult) return null
+
+  const handlePlayAgain = () => {
+    resetGame()
+  }
+
+  return (
+    <main className="final-screen">
+      <h1 className="title mb-2">{t('final_title')}</h1>
+      <p className="mb-4">{t('final_description')}</p>
+      <h2 className="ending-title mb-2">{finalResult.title}</h2>
+      <p className="mb-6 max-w-xl">{finalResult.description}</p>
+
+      {finalResult.card && (
+        <div className="reward-box">
+          <h3 className="font-bold mb-1">{t('card_unlocked')}</h3>
+          <p className="font-semibold">
+            {finalResult.card.name} - {finalResult.card.rarity}
+          </p>
+          <p>{finalResult.card.description}</p>
+        </div>
+      )}
+
+      {finalResult.achievement && (
+        <div className="reward-box">
+          <h3 className="font-bold mb-1">{t('achievement_unlocked')}</h3>
+          <p className="font-semibold">{finalResult.achievement.name}</p>
+          <p>{finalResult.achievement.description}</p>
+        </div>
+      )}
+
+      <button onClick={handlePlayAgain}>{t('play_again')}</button>
+    </main>
+  )
+}

--- a/src/state/gameState.ts
+++ b/src/state/gameState.ts
@@ -17,6 +17,12 @@ export interface GameState {
   selectedLevel: string
   narrativeMemory: string[]
   currentAdvice: string
+  finalResult?: {
+    title: string
+    description: string
+    card?: { name: string; rarity: string; description: string }
+    achievement?: { name: string; description: string }
+  }
   setCurrentAdvice: (advice: string) => void
   updateVariable: (path: string, value: unknown) => void
   resetGame: () => void
@@ -39,6 +45,7 @@ const initialState = {
   selectedLevel: '',
   narrativeMemory: [] as string[],
   currentAdvice: '',
+  finalResult: undefined,
 }
 
 export const useGameState = create<GameState>((set) => ({


### PR DESCRIPTION
## Summary
- create `FinalScreen` to display the ending narrative with optional card and achievement rewards
- update translations with text for the final screen
- extend game state with `finalResult`
- add styles for the final screen
- route `final` screen in `App`

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6852f03405408328ac29bc675fd8991c