### PR TITLE
Implement secret keyword for final screen

### DIFF
--- a/src/lib/sendAdviceToGPT.ts
+++ b/src/lib/sendAdviceToGPT.ts
@@ -1,0 +1,27 @@
+import { useGameState } from '../state/gameState'
+
+export async function sendAdviceToGPT(advice: string): Promise<void> {
+  const state = useGameState.getState()
+
+  if (/azcona/i.test(advice)) {
+    console.log('Secret word detected \u2192 going to final screen')
+    state.updateVariable('finalResult', {
+      title: 'Game Over',
+      description: 'Your words reached the ears of Azcona. The kingdom trembles.',
+      card: {
+        name: 'Mark of Azcona',
+        rarity: 'epic',
+        description: 'A hidden mark left by ancient betrayal.'
+      },
+      achievement: {
+        name: 'Invocation of Azcona',
+        description: 'You dared to speak the forbidden name.'
+      }
+    })
+    state.updateVariable('currentScreen', 'final')
+    return
+  }
+
+  // Normal GPT logic placeholder: for now simply show reaction screen
+  state.updateVariable('currentScreen', 'reaction')
+}

--- a/src/screens/TurnScreen.tsx
+++ b/src/screens/TurnScreen.tsx
@@ -1,16 +1,17 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useGameState } from '../state/gameState'
+import { sendAdviceToGPT } from '../lib/sendAdviceToGPT'
 
 export default function TurnScreen() {
   const { t } = useTranslation()
   const [advice, setAdvice] = useState('')
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     if (!advice.trim()) return
     const state = useGameState.getState()
     state.setCurrentAdvice(advice.trim())
-    state.updateVariable('currentScreen', 'reaction')
+    await sendAdviceToGPT(advice.trim())
   }
 
   return (


### PR DESCRIPTION
## Summary
- add `sendAdviceToGPT` helper that checks for the secret keyword "Azcona"
- redirect player to the final screen with rewards when the keyword is found
- use the new helper from `TurnScreen`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6852f29c6ca08328bde017f11ac1627d