### PR TITLE
Add profile navigation from level select

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -89,6 +89,7 @@
 }
 
 .level-select-screen {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -324,5 +325,40 @@
 .final-screen button:hover {
   transform: translateY(-2px);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+}
+
+.profile-button {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  padding: 0.5rem 1rem;
+  font-size: 0.9rem;
+  border: none;
+  border-radius: 0.5rem;
+  color: #fff;
+  background: linear-gradient(90deg, #667eea, #764ba2);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.profile-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+}
+
+.profile-screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 2rem 1rem;
+  min-height: 100vh;
+  background: linear-gradient(135deg, #f5f7fa, #c3cfe2);
+}
+
+.profile-screen .title {
+  font-size: clamp(2rem, 5vw, 3rem);
+  margin-bottom: 1rem;
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import PresentationScreen from './screens/PresentationScreen'
 import TurnScreen from './screens/TurnScreen'
 import ReactionScreen from './screens/ReactionScreen'
 import FinalScreen from './screens/FinalScreen'
+import ProfileScreen from './screens/ProfileScreen'
 import { useGameState } from './state/gameState'
 
 function App() {
@@ -27,6 +28,10 @@ function App() {
 
   if (currentScreen === 'reaction') {
     return <ReactionScreen />
+  }
+
+  if (currentScreen === 'profile') {
+    return <ProfileScreen />
   }
 
   if (currentScreen === 'final') {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -25,5 +25,8 @@
   "final_description": "The end of your journey",
   "card_unlocked": "New Card Unlocked",
   "achievement_unlocked": "Achievement Unlocked",
-  "play_again": "Play Again"
+  "play_again": "Play Again",
+  "profile_title": "Your Profile",
+  "profile_placeholder": "Unlocked cards and achievements will appear here.",
+  "profile_button": "Profile"
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -25,5 +25,8 @@
   "final_description": "El final de tu viaje",
   "card_unlocked": "Carta desbloqueada",
   "achievement_unlocked": "Logro obtenido",
-  "play_again": "Jugar otra vez"
+  "play_again": "Jugar otra vez",
+  "profile_title": "Tu Perfil",
+  "profile_placeholder": "Las cartas y logros desbloqueados se mostrarán aquí.",
+  "profile_button": "Perfil"
 }

--- a/src/screens/LevelSelectScreen.tsx
+++ b/src/screens/LevelSelectScreen.tsx
@@ -1,11 +1,19 @@
 import { useTranslation } from 'react-i18next'
 import { levelOptions, selectLevel } from '../lib/levelSelectLogic'
+import { useGameState } from '../state/gameState'
 
 export default function LevelSelectScreen() {
   const { t } = useTranslation()
 
+  const openProfile = () => {
+    useGameState.getState().updateVariable('currentScreen', 'profile')
+  }
+
   return (
     <main className="level-select-screen">
+      <button className="profile-button" onClick={openProfile}>
+        {t('profile_button')}
+      </button>
       <h2 className="title">{t('select_level')}</h2>
       <div className="levels">
         {levelOptions.map((level) => (

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -1,0 +1,12 @@
+import { useTranslation } from 'react-i18next'
+
+export default function ProfileScreen() {
+  const { t } = useTranslation()
+
+  return (
+    <main className="profile-screen">
+      <h2 className="title">{t('profile_title')}</h2>
+      <p>{t('profile_placeholder')}</p>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- enable viewing profile in the app
- add profile button on level select screen
- style profile button and screen
- include translations for profile screen

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6852f448e1548328b6853730a4db085c