### PR TITLE
Add Pause menu and debug viewer

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -146,6 +146,7 @@
   }
 }
 .presentation-screen {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -199,6 +200,7 @@
 }
 
 .turn-screen {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -254,6 +256,7 @@
 }
 
 .reaction-screen {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -344,6 +347,80 @@
 .profile-button:hover {
   transform: translateY(-2px);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+}
+
+.pause-button {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+  border: none;
+  border-radius: 50%;
+  color: #fff;
+  background: linear-gradient(90deg, #667eea, #764ba2);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  transition: transform 0.2s, box-shadow 0.2s;
+  padding: 0;
+}
+
+.pause-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+}
+
+.pause-menu {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 2rem 1rem;
+  min-height: 100vh;
+  background: linear-gradient(135deg, #f5f7fa, #c3cfe2);
+}
+
+.pause-menu .title {
+  font-size: clamp(2rem, 5vw, 3rem);
+  margin-bottom: 1.5rem;
+}
+
+.pause-menu .options {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100%;
+  max-width: 400px;
+}
+
+.pause-menu button {
+  padding: 0.75rem 2rem;
+  font-size: 1.1rem;
+  border: none;
+  border-radius: 0.5rem;
+  color: #fff;
+  background: linear-gradient(90deg, #667eea, #764ba2);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.pause-menu button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+}
+
+.pause-menu .debug-block {
+  background: #ffffff;
+  color: #333;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  overflow-x: auto;
+  white-space: pre-wrap;
 }
 
 .profile-screen {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import TurnScreen from './screens/TurnScreen'
 import ReactionScreen from './screens/ReactionScreen'
 import FinalScreen from './screens/FinalScreen'
 import ProfileScreen from './screens/ProfileScreen'
+import PauseMenu from './screens/PauseMenu'
 import { useGameState } from './state/gameState'
 
 function App() {
@@ -28,6 +29,10 @@ function App() {
 
   if (currentScreen === 'reaction') {
     return <ReactionScreen />
+  }
+
+  if (currentScreen === 'pause') {
+    return <PauseMenu />
   }
 
   if (currentScreen === 'profile') {

--- a/src/screens/PauseMenu.tsx
+++ b/src/screens/PauseMenu.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react'
+import { useGameState } from '../state/gameState'
+
+declare const process: { env: Record<string, string | undefined> }
+
+export default function PauseMenu() {
+  const update = useGameState((state) => state.updateVariable)
+  const gameState = useGameState((state) => state)
+  const [showDebug, setShowDebug] = useState(
+    process.env.DEBUG_MODE === 'true' || import.meta.env.DEBUG_MODE === 'true'
+  )
+
+  return (
+    <main className="pause-menu">
+      <h2 className="title">Pause Menu</h2>
+      <div className="options">
+        <button onClick={() => update('currentScreen', 'start')}>
+          Return to Main Menu
+        </button>
+        <button onClick={() => update('currentScreen', 'profile')}>
+          View Profile
+        </button>
+        <button onClick={() => setShowDebug((v) => !v)}>
+          View Current Variables
+        </button>
+        {showDebug && (
+          <pre className="debug-block">
+            {JSON.stringify(gameState, null, 2)}
+          </pre>
+        )}
+      </div>
+    </main>
+  )
+}

--- a/src/screens/PresentationScreen.tsx
+++ b/src/screens/PresentationScreen.tsx
@@ -3,6 +3,7 @@ import { useGameState } from '../state/gameState'
 
 export default function PresentationScreen() {
   const { t } = useTranslation()
+  const update = useGameState((state) => state.updateVariable)
 
   const continueToGame = () => {
     useGameState.getState().updateVariable('currentScreen', 'turn')
@@ -10,6 +11,7 @@ export default function PresentationScreen() {
 
   return (
     <main className="presentation-screen">
+      <button className="pause-button" onClick={() => update('currentScreen', 'pause')}>⚙️</button>
       <h2 className="title">{t('presentation_title')}</h2>
       <div className="king-info">
         <p><strong>Ulric</strong>, the Raven</p>

--- a/src/screens/ReactionScreen.tsx
+++ b/src/screens/ReactionScreen.tsx
@@ -11,6 +11,7 @@ export default function ReactionScreen() {
 
   return (
     <main className="reaction-screen">
+      <button className="pause-button" onClick={() => update('currentScreen', 'pause')}>⚙️</button>
       <h2 className="title">{t('king_reaction_title')}</h2>
 
       <div className="card">

--- a/src/screens/TurnScreen.tsx
+++ b/src/screens/TurnScreen.tsx
@@ -6,6 +6,7 @@ import { sendAdviceToGPT } from '../lib/sendAdviceToGPT'
 export default function TurnScreen() {
   const { t } = useTranslation()
   const [advice, setAdvice] = useState('')
+  const update = useGameState((state) => state.updateVariable)
 
   const handleSubmit = async () => {
     if (!advice.trim()) return
@@ -16,6 +17,7 @@ export default function TurnScreen() {
 
   return (
     <main className="turn-screen">
+      <button className="pause-button" onClick={() => update('currentScreen', 'pause')}>⚙️</button>
       <h2 className="title">{t('your_advice_title')}</h2>
       <section className="dilemma-block">
         <h3 className="dilemma-title">A nobleman accuses the tax collector of corruption</h3>


### PR DESCRIPTION
## Summary
- add PauseMenu screen with buttons for main menu, profile and debugging
- support DEBUG_MODE env variable to show debug info by default
- route `pause` screen in App.tsx
- add floating pause button to presentation, turn and reaction screens
- style pause button and pause menu

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853063f61508328bf97429ac874400a