### PR TITLE
Add global pause menu overlay

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -350,7 +350,7 @@
 }
 
 .pause-button {
-  position: absolute;
+  position: fixed;
   top: 1rem;
   right: 1rem;
   width: 2.5rem;
@@ -366,6 +366,7 @@
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
   transition: transform 0.2s, box-shadow 0.2s;
   padding: 0;
+  z-index: 1000;
 }
 
 .pause-button:hover {
@@ -374,14 +375,25 @@
 }
 
 .pause-menu {
-  position: relative;
+  position: fixed;
+  top: 0;
+  right: 0;
+  height: 100vh;
+  width: 300px;
+  max-width: 80vw;
+  transform: translateX(100%);
+  transition: transform 0.3s ease-in-out;
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: flex-start;
   padding: 2rem 1rem;
-  min-height: 100vh;
   background: linear-gradient(135deg, #f5f7fa, #c3cfe2);
+  box-shadow: -2px 0 8px rgba(0, 0, 0, 0.2);
+  z-index: 999;
+}
+
+.pause-menu.open {
+  transform: translateX(0);
 }
 
 .pause-menu .title {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,43 +7,35 @@ import FinalScreen from './screens/FinalScreen'
 import ProfileScreen from './screens/ProfileScreen'
 import PauseMenu from './screens/PauseMenu'
 import { useGameState } from './state/gameState'
+import type { ReactElement } from 'react'
 
 function App() {
   const currentScreen = useGameState((state) => state.currentScreen)
 
+  let screen: ReactElement | null = null
+
   if (currentScreen === 'start') {
-    return <StartScreen />
+    screen = <StartScreen />
+  } else if (currentScreen === 'levelSelect') {
+    screen = <LevelSelectScreen />
+  } else if (currentScreen === 'presentation') {
+    screen = <PresentationScreen />
+  } else if (currentScreen === 'turn') {
+    screen = <TurnScreen />
+  } else if (currentScreen === 'reaction') {
+    screen = <ReactionScreen />
+  } else if (currentScreen === 'profile') {
+    screen = <ProfileScreen />
+  } else if (currentScreen === 'final') {
+    screen = <FinalScreen />
   }
 
-  if (currentScreen === 'levelSelect') {
-    return <LevelSelectScreen />
-  }
-
-  if (currentScreen === 'presentation') {
-    return <PresentationScreen />
-  }
-
-  if (currentScreen === 'turn') {
-    return <TurnScreen />
-  }
-
-  if (currentScreen === 'reaction') {
-    return <ReactionScreen />
-  }
-
-  if (currentScreen === 'pause') {
-    return <PauseMenu />
-  }
-
-  if (currentScreen === 'profile') {
-    return <ProfileScreen />
-  }
-
-  if (currentScreen === 'final') {
-    return <FinalScreen />
-  }
-
-  return null
+  return (
+    <>
+      {screen}
+      <PauseMenu />
+    </>
+  )
 }
 
 export default App

--- a/src/screens/PauseMenu.tsx
+++ b/src/screens/PauseMenu.tsx
@@ -1,34 +1,57 @@
 import { useState } from 'react'
 import { useGameState } from '../state/gameState'
 
-declare const process: { env: Record<string, string | undefined> }
-
 export default function PauseMenu() {
+  const currentScreen = useGameState((state) => state.currentScreen)
   const update = useGameState((state) => state.updateVariable)
   const gameState = useGameState((state) => state)
-  const [showDebug, setShowDebug] = useState(
-    process.env.DEBUG_MODE === 'true' || import.meta.env.DEBUG_MODE === 'true'
-  )
+  const [isOpen, setIsOpen] = useState(false)
+
+  if (currentScreen === 'start' || currentScreen === 'profile') {
+    return null
+  }
+
+  const toggleMenu = () => setIsOpen((v) => !v)
 
   return (
-    <main className="pause-menu">
-      <h2 className="title">Pause Menu</h2>
-      <div className="options">
-        <button onClick={() => update('currentScreen', 'start')}>
-          Return to Main Menu
-        </button>
-        <button onClick={() => update('currentScreen', 'profile')}>
-          View Profile
-        </button>
-        <button onClick={() => setShowDebug((v) => !v)}>
-          View Current Variables
-        </button>
-        {showDebug && (
-          <pre className="debug-block">
-            {JSON.stringify(gameState, null, 2)}
-          </pre>
-        )}
-      </div>
-    </main>
+    <>
+      <button className="pause-button" onClick={toggleMenu}>
+        ⚙️
+      </button>
+      <aside className={`pause-menu${isOpen ? ' open' : ''}`}>
+        <h2 className="title">Pause Menu</h2>
+        <div className="options">
+          <button
+            onClick={() => {
+              setIsOpen(false)
+              update('currentScreen', 'start')
+            }}
+          >
+            Main Menu
+          </button>
+          <button
+            onClick={() => {
+              setIsOpen(false)
+              update('currentScreen', 'profile')
+            }}
+          >
+            Profile
+          </button>
+          <div className="debug-block">
+            <h3>Debug</h3>
+            <ul>
+              <li>Happiness: {gameState.kingdom.happiness}</li>
+              <li>Wealth: {gameState.kingdom.wealth}</li>
+              <li>Food: {gameState.kingdom.food}</li>
+              <li>Army: {gameState.kingdom.army}</li>
+              <li>Prestige: {gameState.kingdom.prestige}</li>
+              <li>War: {gameState.kingdom.war ? 'Yes' : 'No'}</li>
+              <li>Advisor Trust: {gameState.advisor.trust}</li>
+              <li>Advisor Reputation: {gameState.advisor.reputation}</li>
+            </ul>
+          </div>
+        </div>
+      </aside>
+    </>
   )
 }

--- a/src/screens/PresentationScreen.tsx
+++ b/src/screens/PresentationScreen.tsx
@@ -3,7 +3,6 @@ import { useGameState } from '../state/gameState'
 
 export default function PresentationScreen() {
   const { t } = useTranslation()
-  const update = useGameState((state) => state.updateVariable)
 
   const continueToGame = () => {
     useGameState.getState().updateVariable('currentScreen', 'turn')
@@ -11,7 +10,6 @@ export default function PresentationScreen() {
 
   return (
     <main className="presentation-screen">
-      <button className="pause-button" onClick={() => update('currentScreen', 'pause')}>⚙️</button>
       <h2 className="title">{t('presentation_title')}</h2>
       <div className="king-info">
         <p><strong>Ulric</strong>, the Raven</p>

--- a/src/screens/ReactionScreen.tsx
+++ b/src/screens/ReactionScreen.tsx
@@ -11,7 +11,6 @@ export default function ReactionScreen() {
 
   return (
     <main className="reaction-screen">
-      <button className="pause-button" onClick={() => update('currentScreen', 'pause')}>⚙️</button>
       <h2 className="title">{t('king_reaction_title')}</h2>
 
       <div className="card">

--- a/src/screens/TurnScreen.tsx
+++ b/src/screens/TurnScreen.tsx
@@ -6,7 +6,6 @@ import { sendAdviceToGPT } from '../lib/sendAdviceToGPT'
 export default function TurnScreen() {
   const { t } = useTranslation()
   const [advice, setAdvice] = useState('')
-  const update = useGameState((state) => state.updateVariable)
 
   const handleSubmit = async () => {
     if (!advice.trim()) return
@@ -17,7 +16,6 @@ export default function TurnScreen() {
 
   return (
     <main className="turn-screen">
-      <button className="pause-button" onClick={() => update('currentScreen', 'pause')}>⚙️</button>
       <h2 className="title">{t('your_advice_title')}</h2>
       <section className="dilemma-block">
         <h3 className="dilemma-title">A nobleman accuses the tax collector of corruption</h3>


### PR DESCRIPTION
## Summary
- convert PauseMenu into a fixed side panel
- open menu with a persistent pause button on all screens except start/profile
- remove old per-screen pause buttons
- display game state values in debug block

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853091925488328b19b4f60996d972b