### PR TITLE
Add PauseMenu component with debug section

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -386,9 +386,10 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 2rem 1rem;
-  background: linear-gradient(135deg, #f5f7fa, #c3cfe2);
-  box-shadow: -2px 0 8px rgba(0, 0, 0, 0.2);
+  padding: 1.5rem 1rem;
+  background: rgba(17, 24, 39, 0.95);
+  color: #fff;
+  overflow-y: auto;
   z-index: 999;
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import TurnScreen from './screens/TurnScreen'
 import ReactionScreen from './screens/ReactionScreen'
 import FinalScreen from './screens/FinalScreen'
 import ProfileScreen from './screens/ProfileScreen'
-import PauseMenu from './screens/PauseMenu'
+import PauseMenu from './components/PauseMenu'
 import { useGameState } from './state/gameState'
 import type { ReactElement } from 'react'
 

--- a/src/components/PauseMenu.tsx
+++ b/src/components/PauseMenu.tsx
@@ -1,0 +1,63 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useGameState } from '../state/gameState'
+
+export default function PauseMenu() {
+  const { t } = useTranslation()
+  const currentScreen = useGameState((s) => s.currentScreen)
+  const update = useGameState((s) => s.updateVariable)
+  const gameState = useGameState((s) => s)
+  const [isOpen, setIsOpen] = useState(false)
+
+  if (currentScreen === 'start' || currentScreen === 'profile') {
+    return null
+  }
+
+  const toggleMenu = () => setIsOpen((v) => !v)
+
+  return (
+    <>
+      <button className="pause-button" onClick={toggleMenu}>
+        ⚙️
+      </button>
+      <aside className={`pause-menu${isOpen ? ' open' : ''}`}>
+        <h2 className="title">{t('pause_menu.title')}</h2>
+        <div className="options">
+          <button
+            onClick={() => {
+              setIsOpen(false)
+              update('currentScreen', 'start')
+            }}
+          >
+            {t('pause_menu.main_menu')}
+          </button>
+          <button
+            onClick={() => {
+              setIsOpen(false)
+              update('currentScreen', 'profile')
+            }}
+          >
+            {t('pause_menu.profile')}
+          </button>
+        </div>
+        <div className="debug-block">
+          <h3>{t('pause_menu.debug_title')}</h3>
+          <h4>{t('pause_menu.kingdom')}</h4>
+          <ul>
+            <li>happiness: {gameState.kingdom.happiness}</li>
+            <li>wealth: {gameState.kingdom.wealth}</li>
+            <li>food: {gameState.kingdom.food}</li>
+            <li>army: {gameState.kingdom.army}</li>
+            <li>prestige: {gameState.kingdom.prestige}</li>
+            <li>war: {gameState.kingdom.war ? 'true' : 'false'}</li>
+          </ul>
+          <h4>{t('pause_menu.advisor')}</h4>
+          <ul>
+            <li>trust: {gameState.advisor.trust}</li>
+            <li>reputation: {gameState.advisor.reputation}</li>
+          </ul>
+        </div>
+      </aside>
+    </>
+  )
+}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -28,5 +28,13 @@
   "play_again": "Play Again",
   "profile_title": "Your Profile",
   "profile_placeholder": "Unlocked cards and achievements will appear here.",
-  "profile_button": "Profile"
+  "profile_button": "Profile",
+  "pause_menu": {
+    "title": "Pause Menu",
+    "main_menu": "Return to Main Menu",
+    "profile": "View Profile",
+    "debug_title": "Debug Info",
+    "kingdom": "Kingdom Variables",
+    "advisor": "Advisor Variables"
+  }
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -28,5 +28,13 @@
   "play_again": "Jugar otra vez",
   "profile_title": "Tu Perfil",
   "profile_placeholder": "Las cartas y logros desbloqueados se mostrarán aquí.",
-  "profile_button": "Perfil"
+  "profile_button": "Perfil",
+  "pause_menu": {
+    "title": "Menú de pausa",
+    "main_menu": "Volver al inicio",
+    "profile": "Ver perfil",
+    "debug_title": "Modo debug",
+    "kingdom": "Variables del Reino",
+    "advisor": "Variables del Consejero"
+  }
 }


### PR DESCRIPTION
## Summary
- add new PauseMenu component with open/close state
- update translations for pause menu
- style pause menu with a dark sliding panel
- hook PauseMenu into `App.tsx`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853d98886a48328849019f7d4df0b6a