### PR TITLE
Add runtime game state helper

### DIFF
--- a/src/state/gameState.ts
+++ b/src/state/gameState.ts
@@ -63,3 +63,36 @@ export const useGameState = create<GameState>((set) => ({
   resetGame: () => set(initialState),
   setCurrentAdvice: (advice) => set({ currentAdvice: advice }),
 }))
+
+export interface MainPlot {
+  id: string
+  level: string
+  initialState: {
+    kingdom: Record<string, unknown>
+    advisor: Record<string, unknown>
+  }
+}
+
+export const gameState = {
+  level: '',
+  king: null as Record<string, unknown> | null,
+  kingdom: null as Record<string, unknown> | null,
+  advisor: null as Record<string, unknown> | null,
+  mainPlotId: '',
+  turn: 1,
+  decisions: [] as unknown[],
+  reactions: [] as unknown[],
+  final: null as Record<string, unknown> | null,
+}
+
+export function initializeGameWithPlot(plot: MainPlot) {
+  gameState.level = plot.level
+  gameState.mainPlotId = plot.id
+  gameState.king = null
+  gameState.kingdom = plot.initialState.kingdom
+  gameState.advisor = plot.initialState.advisor
+  gameState.turn = 1
+  gameState.decisions = []
+  gameState.reactions = []
+  gameState.final = null
+}


### PR DESCRIPTION
## Summary
- add `gameState` singleton for the current match values
- create `initializeGameWithPlot` to populate the state from a `MainPlot`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853e2bb0214832882a1decedb0c2a84