### PR TITLE
Load plot data on level select

### DIFF
--- a/src/data/plots.ts
+++ b/src/data/plots.ts
@@ -1,0 +1,22 @@
+import type { MainPlot } from '../state/gameState'
+
+export const plots: MainPlot[] = [
+  {
+    id: 'dark_lineage',
+    level: 'royal',
+    initialState: {
+      kingdom: {
+        happiness: 30,
+        wealth: 40,
+        food: 35,
+        army: 45,
+        prestige: 25,
+        war: false,
+      },
+      advisor: {
+        trust: 40,
+        reputation: 50,
+      },
+    },
+  },
+]

--- a/src/lib/levelSelectLogic.ts
+++ b/src/lib/levelSelectLogic.ts
@@ -1,4 +1,5 @@
-import { useGameState } from '../state/gameState'
+import { useGameState, initializeGameWithPlot } from '../state/gameState'
+import { plots } from '../data/plots'
 
 export interface LevelOption {
   key: string
@@ -17,5 +18,11 @@ export const levelOptions: LevelOption[] = [
 export function selectLevel(level: string) {
   const state = useGameState.getState()
   state.updateVariable('selectedLevel', level)
+
+  const plot = plots.find((p) => p.level === level)
+  if (plot) {
+    initializeGameWithPlot(plot)
+  }
+
   state.updateVariable('currentScreen', 'presentation')
 }


### PR DESCRIPTION
## Summary
- add placeholder plot definitions
- initialize game state from plot when selecting level

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6853e45973cc8328b3f369acbfba59d9