### PR TITLE
Add king selection system

### DIFF
--- a/src/data/kings.ts
+++ b/src/data/kings.ts
@@ -1,0 +1,27 @@
+export interface King {
+  id: string
+  name: string
+  nickname: string
+  personality: 'ruthless' | 'just' | 'cowardly' | 'wise' | 'paranoid'
+  description: string
+  defaultRealmId: string
+}
+
+export const KINGS: King[] = [
+  {
+    id: 'aldric_just',
+    name: 'Aldric',
+    nickname: 'the Just',
+    personality: 'just',
+    description: 'A fair ruler committed to balance and moral duty.',
+    defaultRealmId: 'eldoria'
+  },
+  {
+    id: 'malgar_ruthless',
+    name: 'Malgar',
+    nickname: 'the Iron Fist',
+    personality: 'ruthless',
+    description: 'Rules through fear and unquestioned power.',
+    defaultRealmId: 'gravenrock'
+  }
+]

--- a/src/lib/assignments.ts
+++ b/src/lib/assignments.ts
@@ -1,0 +1,7 @@
+import { KINGS, type King } from '../data/kings'
+
+export function selectKingForPlot(plotId: string): King {
+  if (plotId === 'moral_decay') return KINGS.find(k => k.id === 'aldric_just') || KINGS[0]
+  if (plotId === 'rise_of_war') return KINGS.find(k => k.id === 'malgar_ruthless') || KINGS[0]
+  return KINGS[0]
+}

--- a/src/state/gameState.ts
+++ b/src/state/gameState.ts
@@ -1,4 +1,6 @@
 import { create } from 'zustand'
+import { selectKingForPlot } from '../lib/assignments'
+import type { King } from '../data/kings'
 
 export interface GameState {
   kingdom: {
@@ -75,7 +77,7 @@ export interface MainPlot {
 
 export const gameState = {
   level: '',
-  king: null as Record<string, unknown> | null,
+  king: null as King | null,
   kingdom: null as Record<string, unknown> | null,
   advisor: null as Record<string, unknown> | null,
   mainPlotId: '',
@@ -86,9 +88,10 @@ export const gameState = {
 }
 
 export function initializeGameWithPlot(plot: MainPlot) {
+  const selectedKing = selectKingForPlot(plot.id)
   gameState.level = plot.level
   gameState.mainPlotId = plot.id
-  gameState.king = null
+  gameState.king = selectedKing
   gameState.kingdom = plot.initialState.kingdom
   gameState.advisor = plot.initialState.advisor
   gameState.turn = 1


### PR DESCRIPTION
## Summary
- add a `kings` data file with example rulers
- select a king for each plot via new helper
- store chosen king when initializing a plot

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853e63e0a1c832888681ecf164a6cdc