### PR TITLE
Implement level-based kingdom and king selection

### DIFF
--- a/src/data/kingdoms.ts
+++ b/src/data/kingdoms.ts
@@ -1,0 +1,31 @@
+export interface Kingdom {
+  id: string
+  name: string
+  levels_available: string[]
+  recommended_kings: string[]
+  narrative_tags: string[]
+}
+
+export const KINGDOMS: Kingdom[] = [
+  {
+    id: 'eldoria',
+    name: 'Eldoria',
+    levels_available: ['village', 'governor', 'royal'],
+    recommended_kings: ['aldric_just'],
+    narrative_tags: ['honor', 'justice']
+  },
+  {
+    id: 'gravenrock',
+    name: 'Gravenrock',
+    levels_available: ['governor', 'royal'],
+    recommended_kings: ['malgar_ruthless'],
+    narrative_tags: ['war', 'iron']
+  },
+  {
+    id: 'mystral',
+    name: 'Mystral',
+    levels_available: ['mythical', 'oracle'],
+    recommended_kings: [],
+    narrative_tags: ['arcane', 'mystery']
+  }
+]

--- a/src/lib/assignments.ts
+++ b/src/lib/assignments.ts
@@ -1,7 +1,23 @@
 import { KINGS, type King } from '../data/kings'
+import { KINGDOMS, type Kingdom } from '../data/kingdoms'
 
 export function selectKingForPlot(plotId: string): King {
   if (plotId === 'moral_decay') return KINGS.find(k => k.id === 'aldric_just') || KINGS[0]
   if (plotId === 'rise_of_war') return KINGS.find(k => k.id === 'malgar_ruthless') || KINGS[0]
   return KINGS[0]
+}
+
+export function selectKingdomAndKingForLevel(level: string): { kingdom: Kingdom; king: King } {
+  const availableKingdoms = KINGDOMS.filter(k => k.levels_available.includes(level))
+  const kingdom =
+    availableKingdoms[Math.floor(Math.random() * availableKingdoms.length)] || KINGDOMS[0]
+
+  const recommendedKings = KINGS.filter(k => kingdom.recommended_kings.includes(k.id))
+  let king = recommendedKings[Math.floor(Math.random() * recommendedKings.length)]
+
+  if (!king) {
+    king = KINGS.find(k => k.defaultRealmId === kingdom.id) || KINGS[0]
+  }
+
+  return { kingdom, king }
 }

--- a/src/state/gameState.ts
+++ b/src/state/gameState.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import { selectKingForPlot } from '../lib/assignments'
+import { selectKingdomAndKingForLevel } from '../lib/assignments'
 import type { King } from '../data/kings'
 
 export interface GameState {
@@ -88,11 +88,11 @@ export const gameState = {
 }
 
 export function initializeGameWithPlot(plot: MainPlot) {
-  const selectedKing = selectKingForPlot(plot.id)
+  const { kingdom, king } = selectKingdomAndKingForLevel(plot.level)
   gameState.level = plot.level
   gameState.mainPlotId = plot.id
-  gameState.king = selectedKing
-  gameState.kingdom = plot.initialState.kingdom
+  gameState.king = king
+  gameState.kingdom = { ...kingdom, ...plot.initialState.kingdom }
   gameState.advisor = plot.initialState.advisor
   gameState.turn = 1
   gameState.decisions = []


### PR DESCRIPTION
## Summary
- add kingdom dataset with available levels and recommended kings
- pick random kingdom and associated king based on level
- initialise game with chosen kingdom and king

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6853ea1a1674832882d947b5f4a9e3ee