### PR TITLE
Assign kingdom per plot

### DIFF
--- a/src/data/kingdoms.ts
+++ b/src/data/kingdoms.ts
@@ -1,31 +1,105 @@
 export interface Kingdom {
   id: string
   name: string
+  climate: string
+  religion: string
+  culture: string
+  tags: string[]
   levels_available: string[]
   recommended_kings: string[]
   narrative_tags: string[]
+  happiness: number
+  wealth: number
+  food: number
+  army: number
+  prestige: number
+  war: boolean
 }
 
 export const KINGDOMS: Kingdom[] = [
   {
+    id: 'moral_decay',
+    name: 'Deteria',
+    climate: 'temperate',
+    religion: 'secular',
+    culture: 'decadent',
+    tags: ['corruption', 'decay'],
+    levels_available: ['village', 'governor'],
+    recommended_kings: ['aldric_just'],
+    narrative_tags: ['moral_decay'],
+    happiness: 35,
+    wealth: 45,
+    food: 50,
+    army: 30,
+    prestige: 10,
+    war: false
+  },
+  {
+    id: 'rise_of_war',
+    name: 'Stormgard',
+    climate: 'cold',
+    religion: 'war gods',
+    culture: 'militaristic',
+    tags: ['conquest', 'battle'],
+    levels_available: ['royal'],
+    recommended_kings: ['malgar_ruthless'],
+    narrative_tags: ['rise_of_war'],
+    happiness: 40,
+    wealth: 60,
+    food: 45,
+    army: 70,
+    prestige: 20,
+    war: true
+  },
+  {
     id: 'eldoria',
     name: 'Eldoria',
+    climate: 'mild',
+    religion: 'pantheon',
+    culture: 'honorable',
+    tags: ['justice'],
     levels_available: ['village', 'governor', 'royal'],
     recommended_kings: ['aldric_just'],
-    narrative_tags: ['honor', 'justice']
+    narrative_tags: ['honor', 'justice'],
+    happiness: 50,
+    wealth: 50,
+    food: 50,
+    army: 50,
+    prestige: 0,
+    war: false
   },
   {
     id: 'gravenrock',
     name: 'Gravenrock',
+    climate: 'rocky',
+    religion: 'forge cult',
+    culture: 'warlike',
+    tags: ['iron', 'blood'],
     levels_available: ['governor', 'royal'],
     recommended_kings: ['malgar_ruthless'],
-    narrative_tags: ['war', 'iron']
+    narrative_tags: ['war', 'iron'],
+    happiness: 45,
+    wealth: 55,
+    food: 40,
+    army: 60,
+    prestige: 15,
+    war: true
   },
   {
     id: 'mystral',
     name: 'Mystral',
+    climate: 'arid',
+    religion: 'mystic',
+    culture: 'arcane',
+    tags: ['mystery'],
     levels_available: ['mythical', 'oracle'],
     recommended_kings: [],
-    narrative_tags: ['arcane', 'mystery']
+    narrative_tags: ['arcane', 'mystery'],
+    happiness: 55,
+    wealth: 40,
+    food: 35,
+    army: 30,
+    prestige: 25,
+    war: false
   }
 ]

--- a/src/lib/assignments.ts
+++ b/src/lib/assignments.ts
@@ -7,6 +7,12 @@ export function selectKingForPlot(plotId: string): King {
   return KINGS[0]
 }
 
+export function selectKingdomForPlot(plotId: string): Kingdom {
+  if (plotId === 'moral_decay') return KINGDOMS.find(k => k.id === 'moral_decay') || KINGDOMS[0]
+  if (plotId === 'rise_of_war') return KINGDOMS.find(k => k.id === 'rise_of_war') || KINGDOMS[0]
+  return KINGDOMS[0]
+}
+
 export function selectKingdomAndKingForLevel(level: string): { kingdom: Kingdom; king: King } {
   const availableKingdoms = KINGDOMS.filter(k => k.levels_available.includes(level))
   const kingdom =

--- a/src/state/gameState.ts
+++ b/src/state/gameState.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
-import { selectKingdomAndKingForLevel } from '../lib/assignments'
+import { selectKingForPlot, selectKingdomForPlot } from '../lib/assignments'
 import type { King } from '../data/kings'
+import type { Kingdom } from '../data/kingdoms'
 
 export interface GameState {
   kingdom: {
@@ -78,7 +79,7 @@ export interface MainPlot {
 export const gameState = {
   level: '',
   king: null as King | null,
-  kingdom: null as Record<string, unknown> | null,
+  kingdom: null as Kingdom | null,
   advisor: null as Record<string, unknown> | null,
   mainPlotId: '',
   turn: 1,
@@ -88,11 +89,12 @@ export const gameState = {
 }
 
 export function initializeGameWithPlot(plot: MainPlot) {
-  const { kingdom, king } = selectKingdomAndKingForLevel(plot.level)
+  const king = selectKingForPlot(plot.id)
+  const kingdom = selectKingdomForPlot(plot.id)
   gameState.level = plot.level
   gameState.mainPlotId = plot.id
   gameState.king = king
-  gameState.kingdom = { ...kingdom, ...plot.initialState.kingdom }
+  gameState.kingdom = kingdom
   gameState.advisor = plot.initialState.advisor
   gameState.turn = 1
   gameState.decisions = []


### PR DESCRIPTION
## Summary
- expand `Kingdom` data to include climate, religion, culture, tags and base stats
- map plots to kingdoms with new `selectKingdomForPlot`
- update game state initialization to use the selected kingdom
- type `gameState.kingdom` as `Kingdom`

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6853eb5522288328a963752103a88c37