### PR TITLE
Show kingdom information in presentation screen

### DIFF
--- a/src/screens/PresentationScreen.tsx
+++ b/src/screens/PresentationScreen.tsx
@@ -3,6 +3,7 @@ import { useGameState } from '../state/gameState'
 
 export default function PresentationScreen() {
   const { t } = useTranslation()
+  const kingdom = useGameState((state) => state.kingdom)
 
   const continueToGame = () => {
     useGameState.getState().updateVariable('currentScreen', 'turn')
@@ -17,9 +18,36 @@ export default function PresentationScreen() {
         <p>Throne: A dark hall lit by torches, tapestries worn by time.</p>
         <p>Quote: "I warn you: I do not tolerate failure."</p>
       </div>
-      <div className="kingdom-info">
-        <p>Context: A realm marked by betrayal and plague.</p>
-      </div>
+      {kingdom ? (
+        <div className="kingdom-info">
+          <p>
+            <strong>Kingdom:</strong> {kingdom.name}
+          </p>
+          <p>
+            <strong>Climate:</strong> {kingdom.climate}
+          </p>
+          <p>
+            <strong>Religion:</strong> {kingdom.religion}
+          </p>
+          <p>
+            <strong>Culture:</strong> {kingdom.culture}
+          </p>
+          <p>
+            <strong>Dominant Class:</strong> {kingdom.dominant_class}
+          </p>
+          <p>
+            <strong>Political System:</strong> {kingdom.political_system}
+          </p>
+          <p>
+            <strong>Current Crisis:</strong> {kingdom.current_crisis}
+          </p>
+          <p>
+            <strong>Tags:</strong> {kingdom.tags.join(', ')}
+          </p>
+        </div>
+      ) : (
+        <p>Loading kingdom...</p>
+      )}
       <button onClick={continueToGame}>{t('continue')}</button>
     </main>
   )


### PR DESCRIPTION
## Summary
- display kingdom details on the presentation screen using `useGameState`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853ef8a9e388328be21772fb9dc4ce8