### PR TITLE
Display king data on presentation screen

### DIFF
--- a/src/screens/PresentationScreen.tsx
+++ b/src/screens/PresentationScreen.tsx
@@ -3,6 +3,7 @@ import { useGameState } from '../state/gameState'
 
 export default function PresentationScreen() {
   const { t } = useTranslation()
+  const king = useGameState((state) => state.king)
 
   const continueToGame = () => {
     useGameState.getState().updateVariable('currentScreen', 'turn')
@@ -11,12 +12,17 @@ export default function PresentationScreen() {
   return (
     <main className="presentation-screen">
       <h2 className="title">{t('presentation_title')}</h2>
-      <div className="king-info">
-        <p><strong>Ulric</strong>, the Raven</p>
-        <p>Personality: paranoid and meticulous</p>
-        <p>Throne: A dark hall lit by torches, tapestries worn by time.</p>
-        <p>Quote: "I warn you: I do not tolerate failure."</p>
-      </div>
+      {king ? (
+        <div className="king-info">
+          <p>
+            <strong>King:</strong> {king.name} {king.nickname}
+          </p>
+          <p>Personality: {king.personality}</p>
+          <p>Description: {king.description}</p>
+        </div>
+      ) : (
+        <div className="king-info">Loading king...</div>
+      )}
       <div className="kingdom-info">
         <p>Context: A realm marked by betrayal and plague.</p>
       </div>

--- a/src/state/gameState.ts
+++ b/src/state/gameState.ts
@@ -4,6 +4,7 @@ import type { King } from '../data/kings'
 import type { Kingdom } from '../data/kingdoms'
 
 export interface GameState {
+  king: King | null
   kingdom: Kingdom | null
   advisor: {
     trust: number
@@ -25,6 +26,7 @@ export interface GameState {
 }
 
 const initialState = {
+  king: null as King | null,
   kingdom: null as Kingdom | null,
   advisor: {
     trust: 50,
@@ -86,4 +88,9 @@ export function initializeGameWithPlot(plot: MainPlot) {
   gameState.decisions = []
   gameState.reactions = []
   gameState.final = null
+
+  const update = useGameState.getState().updateVariable
+  update('king', selectedKing)
+  update('kingdom', selectedKingdom)
+  update('advisor', plot.initialState.advisor)
 }


### PR DESCRIPTION
## Summary
- store selected king in game state
- show king information on the presentation screen

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853efd65c9083288d78e5e2e5335c0d