### PR TITLE
Refactor PresentationScreen UI into components

### DIFF
--- a/src/components/KingPresentation.tsx
+++ b/src/components/KingPresentation.tsx
@@ -1,0 +1,33 @@
+import type { FC } from 'react'
+
+export interface King {
+  name: string
+  nickname: string
+  personality: string
+  description: string
+  quote: string
+}
+
+interface Props {
+  king?: Partial<King> | null
+}
+
+const KingPresentation: FC<Props> = ({ king }) => {
+  if (!king) {
+    return <div className="king-info">Loading king...</div>
+  }
+
+  return (
+    <div className="king-info">
+      <p>
+        <strong>{king.name ?? 'Unknown'}</strong>
+        {king.nickname ? `, ${king.nickname}` : ''}
+      </p>
+      <p>Personality: {king.personality ?? 'Unknown'}</p>
+      <p>Throne: {king.description ?? 'No description available.'}</p>
+      <p>Quote: {king.quote ?? '...'}</p>
+    </div>
+  )
+}
+
+export default KingPresentation

--- a/src/components/KingdomPresentation.tsx
+++ b/src/components/KingdomPresentation.tsx
@@ -1,0 +1,19 @@
+import type { FC } from 'react'
+
+interface Props {
+  context?: string | null
+}
+
+const KingdomPresentation: FC<Props> = ({ context }) => {
+  if (!context) {
+    return <div className="kingdom-info">Loading context...</div>
+  }
+
+  return (
+    <div className="kingdom-info">
+      <p>{context}</p>
+    </div>
+  )
+}
+
+export default KingdomPresentation

--- a/src/screens/PresentationScreen.tsx
+++ b/src/screens/PresentationScreen.tsx
@@ -1,10 +1,20 @@
 import { useTranslation } from 'react-i18next'
 import { useGameState } from '../state/gameState'
+import KingPresentation from '../components/KingPresentation'
+import KingdomPresentation from '../components/KingdomPresentation'
 
 export default function PresentationScreen() {
   const { t } = useTranslation()
   const king = useGameState((state) => state.king)
   const kingdom = useGameState((state) => state.kingdom)
+
+  const sampleKing = {
+    name: 'Ulric',
+    nickname: 'the Raven',
+    personality: 'paranoid and meticulous',
+    description: 'A dark hall lit by torches, tapestries worn by time.',
+    quote: 'I warn you: I do not tolerate failure.'
+  }
 
   const continueToGame = () => {
     useGameState.getState().updateVariable('currentScreen', 'turn')
@@ -13,26 +23,9 @@ export default function PresentationScreen() {
   return (
     <main className="presentation-screen">
       <h2 className="title">{t('presentation_title')}</h2>
-      {king ? (
-        <div className="king-info">
-          <p>
-            <strong>King:</strong> {king.name} {king.nickname}
-          </p>
-          <p>Personality: {king.personality}</p>
-          <p>Description: {king.description}</p>
-        </div>
-      ) : (
-        <div className="king-info">Loading king...</div>
-      )}
-      <div className="kingdom-info">
-        <p>Context: A realm marked by betrayal and plague.</p>
-      </div>
-      <div className="king-info">
-        <p><strong>Ulric</strong>, the Raven</p>
-        <p>Personality: paranoid and meticulous</p>
-        <p>Throne: A dark hall lit by torches, tapestries worn by time.</p>
-        <p>Quote: "I warn you: I do not tolerate failure."</p>
-      </div>
+      <KingPresentation king={king} />
+      <KingdomPresentation context="A realm marked by betrayal and plague." />
+      <KingPresentation king={sampleKing} />
       {kingdom ? (
         <div className="kingdom-info">
           <p>


### PR DESCRIPTION
## Summary
- add `KingPresentation` component to encapsulate king intro UI
- add `KingdomPresentation` component for short kingdom context
- use the new components in `PresentationScreen`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6853f4607bd48328993e823b76043d5f